### PR TITLE
Fix code scanning alert #17: Comparison of narrow type with wide type in loop condition

### DIFF
--- a/GpApp/SelectHouse.cpp
+++ b/GpApp/SelectHouse.cpp
@@ -524,7 +524,7 @@ void DoLoadHouse (void)
 void SortHouseList (void)
 {
 	VFileSpec	tempSpec;
-	short		i, h, whosFirst;
+	int		i, h, whosFirst;
 	
 	i = 0;			// remove exact duplicate houses
 	while (i < housesFound)


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/Aerofoil/security/code-scanning/17](https://github.com/cooljeanius/Aerofoil/security/code-scanning/17)

_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
