### PR TITLE
Fix code scanning alert no. 16: Comparison of narrow type with wide type in loop condition

### DIFF
--- a/FreeType/freetype/src/winfonts/winfnt.c
+++ b/FreeType/freetype/src/winfonts/winfnt.c
@@ -411,8 +411,7 @@
         WinPE_RsrcDataEntryRec  data_entry;
 
         FT_ULong   root_dir_offset, name_dir_offset, lang_dir_offset;
-        FT_UShort  i, j;
-        FT_UInt    k;
+        FT_UInt  i, j, k;
 
 
         FT_TRACE2(( "PE signature found\n" ));

--- a/FreeType/freetype/src/winfonts/winfnt.c
+++ b/FreeType/freetype/src/winfonts/winfnt.c
@@ -411,7 +411,8 @@
         WinPE_RsrcDataEntryRec  data_entry;
 
         FT_ULong   root_dir_offset, name_dir_offset, lang_dir_offset;
-        FT_UShort  i, j, k;
+        FT_UShort  i, j;
+        FT_UInt    k;
 
 
         FT_TRACE2(( "PE signature found\n" ));


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/Aerofoil/security/code-scanning/16](https://github.com/cooljeanius/Aerofoil/security/code-scanning/16)

_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
