### PR TITLE
Fix code scanning alert no. 13: Multiplication result converted to larger type

### DIFF
--- a/zlib/zutil.c
+++ b/zlib/zutil.c
@@ -308,7 +308,7 @@ voidpf ZLIB_INTERNAL zcalloc (opaque, items, size)
     unsigned size;
 {
     (void)opaque;
-    return sizeof(uInt) > 2 ? (voidpf)malloc(items * size) :
+    return sizeof(uInt) > 2 ? (voidpf)malloc((size_t)items * size) :
                               (voidpf)calloc(items, size);
 }
 


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/Aerofoil/security/code-scanning/13](https://github.com/cooljeanius/Aerofoil/security/code-scanning/13)

To fix the problem, we need to ensure that the multiplication is performed using a larger integer type to prevent overflow. This can be achieved by casting one of the operands to `size_t` before performing the multiplication. This way, the multiplication will be done in the larger type, and the result will not overflow.

- Cast one of the operands (`items` or `size`) to `size_t` before the multiplication.
- This change should be made on line 311 of the file `zlib/zutil.c`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
