### PR TITLE
Fix code scanning alert no. 12: Multiplication result converted to larger type

### DIFF
--- a/stb/stb_image_write.h
+++ b/stb/stb_image_write.h
@@ -789,7 +789,7 @@ STBIWDEF int stbi_write_hdr(char const *filename, int x, int y, int comp, const 
 static void *stbiw__sbgrowf(void **arr, int increment, int itemsize)
 {
    int m = *arr ? 2*stbiw__sbm(*arr)+increment : increment+1;
-   void *p = STBIW_REALLOC_SIZED(*arr ? stbiw__sbraw(*arr) : 0, *arr ? (stbiw__sbm(*arr)*itemsize + sizeof(int)*2) : 0, (unsigned long long)itemsize * m + sizeof(int)*2);
+   void *p = STBIW_REALLOC_SIZED(*arr ? stbiw__sbraw(*arr) : 0, *arr ? (stbiw__sbm(*arr)*itemsize + sizeof(int)*2) : 0, (size_t)itemsize * m + sizeof(int)*2);
    STBIW_ASSERT(p);
    if (p) {
       if (!*arr) ((int *) p)[1] = 0;

--- a/stb/stb_image_write.h
+++ b/stb/stb_image_write.h
@@ -789,7 +789,7 @@ STBIWDEF int stbi_write_hdr(char const *filename, int x, int y, int comp, const 
 static void *stbiw__sbgrowf(void **arr, int increment, int itemsize)
 {
    int m = *arr ? 2*stbiw__sbm(*arr)+increment : increment+1;
-   void *p = STBIW_REALLOC_SIZED(*arr ? stbiw__sbraw(*arr) : 0, *arr ? (stbiw__sbm(*arr)*itemsize + sizeof(int)*2) : 0, itemsize * m + sizeof(int)*2);
+   void *p = STBIW_REALLOC_SIZED(*arr ? stbiw__sbraw(*arr) : 0, *arr ? (stbiw__sbm(*arr)*itemsize + sizeof(int)*2) : 0, (unsigned long long)itemsize * m + sizeof(int)*2);
    STBIW_ASSERT(p);
    if (p) {
       if (!*arr) ((int *) p)[1] = 0;


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/Aerofoil/security/code-scanning/12](https://github.com/cooljeanius/Aerofoil/security/code-scanning/12)

To fix the problem, we need to ensure that the multiplication is performed using a larger integer type to prevent overflow. This can be done by casting one of the operands to `unsigned long long` before the multiplication. This way, the multiplication will be performed using the larger type, and the result will not overflow.

- Cast `itemsize` to `unsigned long long` before multiplying it with `m`.
- This change should be made on line 792 in the file `stb/stb_image_write.h`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
