### PR TITLE
Fix code scanning alert no. 11: Multiplication result converted to larger type

### DIFF
--- a/stb/stb_image_write.h
+++ b/stb/stb_image_write.h
@@ -1046,7 +1046,7 @@ static void stbiw__encode_png_line(unsigned char *pixels, int stride_bytes, int 
    int signed_stride = stbi__flip_vertically_on_write ? -stride_bytes : stride_bytes;
     
    if (type==0) {
-      memcpy(line_buffer, z, width*n);
+      memcpy(line_buffer, z, (size_t)width*n);
       return;
    }
 


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/Aerofoil/security/code-scanning/11](https://github.com/cooljeanius/Aerofoil/security/code-scanning/11)

To fix the problem, we need to ensure that the multiplication is performed using a larger integer type to prevent overflow. This can be done by casting one of the operands to `size_t` before the multiplication. This way, the multiplication will be performed in the `size_t` type, which has a larger range than `int`.

The best way to fix this without changing existing functionality is to cast `width` to `size_t` before the multiplication. This change should be made in the `stbiw__encode_png_line` function on line 1049.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
