### PR TITLE
Fix code scanning alert no. 10: Multiplication result converted to larger type

### DIFF
--- a/stb/stb_image_write.h
+++ b/stb/stb_image_write.h
@@ -1116,7 +1116,7 @@ STBIWDEF unsigned char *stbi_write_png_to_mem(const unsigned char *pixels, int s
       }
       // when we get here, filter_type contains the filter type, and line_buffer contains the data
       filt[j*(x*n+1)] = (unsigned char) filter_type;
-      STBIW_MEMMOVE(filt+j*(x*n+1)+1, line_buffer, x*n);
+      STBIW_MEMMOVE(filt+j*(x*(size_t)n+1)+1, line_buffer, x*(size_t)n);
    }
    STBIW_FREE(line_buffer);
    zlib = stbi_zlib_compress(filt, y*( x*n+1), &zlen, stbi_write_png_compression_level);


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/Aerofoil/security/code-scanning/10](https://github.com/cooljeanius/Aerofoil/security/code-scanning/10)

To fix the problem, we need to ensure that the multiplication is performed using a larger integer type to prevent overflow. This can be done by casting one of the operands to `size_t` before performing the multiplication. This way, the multiplication will be done in the `size_t` type, which is large enough to hold the result without overflow.

The specific change involves casting `x` or `n` to `size_t` in the multiplication expression on line 1119.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
