### PR TITLE
Fix code scanning alert no. 9: Multiplication result converted to larger type

### DIFF
--- a/stb/stb_image_write.h
+++ b/stb/stb_image_write.h
@@ -1087,8 +1087,8 @@ STBIWDEF unsigned char *stbi_write_png_to_mem(const unsigned char *pixels, int s
       force_filter = -1;
    }
 
-   filt = (unsigned char *) STBIW_MALLOC((x*n+1) * y); if (!filt) return 0;
-   line_buffer = (signed char *) STBIW_MALLOC(x * n); if (!line_buffer) { STBIW_FREE(filt); return 0; }
+   filt = (unsigned char *) STBIW_MALLOC(((size_t)x*n+1) * y); if (!filt) return 0;
+   line_buffer = (signed char *) STBIW_MALLOC((size_t)x * n); if (!line_buffer) { STBIW_FREE(filt); return 0; }
    for (j=0; j < y; ++j) {
       int filter_type;
       if (force_filter > -1) {


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/Aerofoil/security/code-scanning/9](https://github.com/cooljeanius/Aerofoil/security/code-scanning/9)

To fix the problem, we need to ensure that the multiplication is performed using a larger integer type to prevent overflow. This can be done by casting one of the operands to `size_t` before performing the multiplication. This way, the multiplication will be done in the `size_t` type, which is large enough to hold the result without overflow.

The specific change involves casting `x` to `size_t` in the multiplication expression on line 1091. This change should be made in the file `stb/stb_image_write.h`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
