### PR TITLE
Fix code scanning alert no. 7: Multiplication result converted to larger type

### DIFF
--- a/PortabilityLayer/ScanlineMaskConverter.cpp
+++ b/PortabilityLayer/ScanlineMaskConverter.cpp
@@ -129,7 +129,7 @@ namespace PortabilityLayer
 		if (static_cast<uint64_t>(width) * static_cast<uint64_t>(height) > SIZE_MAX)
 			return nullptr;
 
-		const size_t numElements = static_cast<uint64_t>(width) * static_cast<uint64_t>(height);
+		const size_t numElements = static_cast<size_t>(width) * static_cast<size_t>(height);
 
 #if PL_SCANLINE_MASKS_DEBUGGING
 		const size_t storageSize = numElements * 4;

--- a/PortabilityLayer/ScanlineMaskConverter.cpp
+++ b/PortabilityLayer/ScanlineMaskConverter.cpp
@@ -129,7 +129,7 @@ namespace PortabilityLayer
 		if (static_cast<uint64_t>(width) * static_cast<uint64_t>(height) > SIZE_MAX)
 			return nullptr;
 
-		const size_t numElements = width * height;
+		const size_t numElements = static_cast<uint64_t>(width) * static_cast<uint64_t>(height);
 
 #if PL_SCANLINE_MASKS_DEBUGGING
 		const size_t storageSize = numElements * 4;


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/Aerofoil/security/code-scanning/7](https://github.com/cooljeanius/Aerofoil/security/code-scanning/7)

To fix the problem, we need to ensure that the multiplication is performed using a larger integer type to prevent overflow. This can be achieved by casting one or both operands to `uint64_t` before performing the multiplication. This way, the multiplication will be done using 64-bit arithmetic, which can handle larger values without overflow.

- Cast `width` and `height` to `uint64_t` before multiplying them.
- This change should be made on line 132 where the multiplication occurs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
