### PR TITLE
Fix code scanning alert no. 6: Multiplication result converted to larger type

### DIFF
--- a/PortabilityLayer/DeflateCodec.cpp
+++ b/PortabilityLayer/DeflateCodec.cpp
@@ -15,7 +15,7 @@ namespace
 {
 	static voidpf ZlibAllocShim(voidpf opaque, uInt items, uInt size)
 	{
-		return static_cast<PortabilityLayer::MemoryManager*>(opaque)->Alloc(items * size);
+		return static_cast<PortabilityLayer::MemoryManager*>(opaque)->Alloc(static_cast<size_t>(items) * size);
 	}
 
 	void ZlibFreeShim(voidpf opaque, voidpf address)


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/Aerofoil/security/code-scanning/6](https://github.com/cooljeanius/Aerofoil/security/code-scanning/6)

To fix the problem, we need to ensure that the multiplication is performed using the larger integer type (`size_t`) to prevent overflow. This can be achieved by casting one of the operands to `size_t` before performing the multiplication. This way, the multiplication will be done in the `size_t` type, which has a larger range than `uInt`.

The best way to fix this without changing existing functionality is to cast `items` to `size_t` before the multiplication. This change should be made on line 18 of the file `PortabilityLayer/DeflateCodec.cpp`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
