### PR TITLE
Fix code scanning alert no. 5: Multiplication result converted to larger type

### DIFF
--- a/GpApp/AnimCursor.cpp
+++ b/GpApp/AnimCursor.cpp
@@ -201,7 +201,7 @@ IGpCursor *LoadColorCursor(int16_t resID)
 		memcpy(decodedCTabItems + index, rgba, 4);
 	}
 
-	uint32_t *pixelDataRGBA = static_cast<uint32_t*>(mm->Alloc(width * height * 4));
+	uint32_t *pixelDataRGBA = static_cast<uint32_t*>(mm->Alloc(static_cast<size_t>(width) * static_cast<size_t>(height) * 4));
 	if (!pixelDataRGBA)
 	{
 		mm->Release(colorValues);


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/Aerofoil/security/code-scanning/5](https://github.com/cooljeanius/Aerofoil/security/code-scanning/5)

To fix the problem, we need to ensure that the multiplication is performed using a larger integer type to avoid overflow. The best way to do this is to cast the operands to `size_t` before performing the multiplication. This will ensure that the multiplication is done using the larger type, preventing overflow.

- Change the multiplication on line 204 to cast `width` and `height` to `size_t` before performing the multiplication.
- No additional methods or definitions are needed.
- No changes to imports are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
