### PR TITLE
Fix code scanning alert no. 4: Multiplication result converted to larger type

### DIFF
--- a/GpApp/AnimCursor.cpp
+++ b/GpApp/AnimCursor.cpp
@@ -144,7 +144,7 @@ IGpCursor *LoadColorCursor(int16_t resID)
 
 	PortabilityLayer::MemoryManager *mm = PortabilityLayer::MemoryManager::GetInstance();
 
-	uint8_t *colorValues = static_cast<uint8_t*>(mm->Alloc(width * height));
+	uint8_t *colorValues = static_cast<uint8_t*>(mm->Alloc(static_cast<size_t>(width) * height));
 	if (!colorValues)
 	{
 		resHdl.Dispose();


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/Aerofoil/security/code-scanning/4](https://github.com/cooljeanius/Aerofoil/security/code-scanning/4)

To fix the problem, we need to ensure that the multiplication is performed using a larger type to prevent overflow. This can be done by casting one of the operands to `size_t` before performing the multiplication. This way, the multiplication will be done in the larger type, and the result will be correct.

- Cast one of the operands (`width` or `height`) to `size_t` before the multiplication.
- This change should be made on line 147 where the multiplication occurs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
