### PR TITLE
Fix code scanning alert no. 3: Multiplication result converted to larger type

### DIFF
--- a/FreeType/freetype/src/truetype/ttgxvar.c
+++ b/FreeType/freetype/src/truetype/ttgxvar.c
@@ -2142,7 +2142,7 @@
                                    sizeof ( FT_Var_Axis ) );
     namedstyle_size  = ALIGN_SIZE( num_instances *
                                    sizeof ( FT_Var_Named_Style ) );
-    next_coords_size = ALIGN_SIZE( num_instances *
+    next_coords_size = ALIGN_SIZE( (FT_ULong)num_instances *
                                    num_axes *
                                    sizeof ( FT_Fixed ) );
     next_name_size   = num_axes * 5;

--- a/FreeType/freetype/src/truetype/ttgxvar.c
+++ b/FreeType/freetype/src/truetype/ttgxvar.c
@@ -2142,9 +2142,9 @@
                                    sizeof ( FT_Var_Axis ) );
     namedstyle_size  = ALIGN_SIZE( num_instances *
                                    sizeof ( FT_Var_Named_Style ) );
-    next_coords_size = ALIGN_SIZE( (FT_ULong)num_instances *
-                                   num_axes *
-                                   sizeof ( FT_Fixed ) );
+    next_coords_size = ALIGN_SIZE((size_t)num_instances *
+                                  (size_t)num_axes *
+                                  sizeof(FT_Fixed));
     next_name_size   = num_axes * 5;
 
     if ( need_init )


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/Aerofoil/security/code-scanning/3](https://github.com/cooljeanius/Aerofoil/security/code-scanning/3)

To fix the problem, we need to ensure that the multiplication is performed using a larger integer type to prevent overflow. This can be achieved by casting one of the operands to `FT_ULong` before performing the multiplication. This way, the multiplication will be done in the larger type, avoiding overflow.

- **General Fix:** Cast one of the operands to `FT_ULong` before the multiplication.
- **Detailed Fix:** In the specific lines where the multiplication occurs, cast `num_instances` or `num_axes` to `FT_ULong` before multiplying.
- **Lines to Change:** Lines 2145-2147 in the file `FreeType/freetype/src/truetype/ttgxvar.c`.
- **Requirements:** No additional methods, imports, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
