### PR TITLE
Fix code scanning alert no. 2: Mismatching new/free or malloc/delete

### DIFF
--- a/unpacktool/StuffItArsenicDecompressor.cpp
+++ b/unpacktool/StuffItArsenicDecompressor.cpp
@@ -287,7 +287,7 @@ bool StuffItArsenicDecompressor::ReadBlock()
 		endofblocks=true;
 	}
 
-	free(transform);
+	delete[] transform;
 	transform = new uint32_t[numbytes];
 	CalculateInverseBWT(transform,block,numbytes);
 


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/Aerofoil/security/code-scanning/2](https://github.com/cooljeanius/Aerofoil/security/code-scanning/2)

To fix the problem, we need to ensure that the memory allocated with `new[]` is deallocated using `delete[]`. Specifically, we should replace the `free(transform)` call with `delete[] transform`. This change will ensure that the memory management functions are correctly paired, preventing undefined behavior.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
