### PR TITLE
Fix code scanning alert no. 1: DOM text reinterpreted as HTML

### DIFF
--- a/SDL2-2.0.12/test/nacl/common.js
+++ b/SDL2-2.0.12/test/nacl/common.js
@@ -18,6 +18,23 @@ var isRelease = true;
 // code.
 var common = (function() {
 
+  function escapeHtml(unsafe) {
+    return unsafe.replace(/[&<"']/g, function (m) {
+      switch (m) {
+        case '&':
+          return '&amp;';
+        case '<':
+          return '&lt;';
+        case '"':
+          return '&quot;';
+        case "'":
+          return '&#039;';
+        default:
+          return m;
+      }
+    });
+  }
+
   function isHostToolchain(tool) {
     return tool == 'win' || tool == 'linux' || tool == 'mac';
   }
@@ -127,7 +144,7 @@ var common = (function() {
     moduleEl.setAttribute('width', width);
     moduleEl.setAttribute('height', height);
     moduleEl.setAttribute('path', path);
-    moduleEl.setAttribute('src', path + '/' + name + '.nmf');
+    moduleEl.setAttribute('src', path + '/' + escapeHtml(name) + '.nmf');
 
     // Add any optional arguments
     if (attrs) {


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/Aerofoil/security/code-scanning/1](https://github.com/cooljeanius/Aerofoil/security/code-scanning/1)

To fix the problem, we need to ensure that the `name` variable is properly sanitized or escaped before being used to construct the URL for the `src` attribute. One effective way to do this is to use a function that escapes any potentially dangerous characters in the `name` variable.

We will:
1. Introduce a utility function to escape HTML special characters.
2. Use this function to sanitize the `name` variable before it is used in the `createNaClModule` function.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
